### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluent::Plugin::ConditionalFilter [![BuildStatus](https://secure.travis-ci.org/kentaro/fluent-plugin-conditional_filter.png)](http://travis-ci.org/kentaro/fluent-plugin-conditional_filter)
+# Fluent::Plugin::ConditionalFilter, a plugin for [Fluentd](http://fluentd.org) [![BuildStatus](https://secure.travis-ci.org/kentaro/fluent-plugin-conditional_filter.png)](http://travis-ci.org/kentaro/fluent-plugin-conditional_filter)
 
 ## Component
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
