### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,57 @@
 
 ## Component
 
+### ConditionalFilter
+
+fluent-plugin-conditional_filter provides a simple filter that filters out key/value pairs that don't satisfy a given condition. This is the filter version of [ConditionalFilterOutput](#conditionalfilteroutput).
+
+## Usage
+
+### Synopsis
+
+If there's such a configuration as below:
+
+```
+<filter test.**>
+  type           conditional
+  key_pattern    @example\.com$
+  condition      10
+  filter         numeric_upward
+</filter>
+```
+
+When the log below reaches:
+
+```
+'test' => {
+  'foo@example.com' => 5,
+  'bar@example.com' => 15,
+  'baz@baz.com'     => 12,
+}
+```
+
+key/value pairs that don't match either `key_pattern` or the condition designated by `condition` and `filter` are filtered out.
+
+```
+'filtered.test' => {
+  'bar@example.com' => 15,
+}
+```
+
+### Params
+
+#### `key_pattern` (required)
+
+Key pattern to check.
+
+#### `condition` (required)
+
+Condition for the filter below.
+
+#### `filter` (required)
+
+Set filtering strategy.
+
 ### ConditionalFilterOutput
 
 fluent-plugin-conditional_filter provides a simple filter that filters out key/value pairs that don't satisfy a given condition.

--- a/fluent-plugin-conditional_filter.gemspec
+++ b/fluent-plugin-conditional_filter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'fluentd'
+  spec.add_runtime_dependency 'fluentd', [">= 0.14.0", "< 2"]
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/fluent/plugin/conditional_filter_rule.rb
+++ b/lib/fluent/plugin/conditional_filter_rule.rb
@@ -1,0 +1,30 @@
+require 'fluent/output'
+
+module Fluent
+  module ConditionalFilterRule
+    def filter_record(tag, time, record, plugin)
+      super(tag, time, record) if plugin.is_a?(Fluent::Output)
+      case @filter
+      when 'numeric_upward'
+        filter_record = record.select do |key, value|
+          key.match(@key_pattern_regexp) &&
+            record[key].to_f >= @condition.to_f
+        end
+      when 'numeric_downward'
+        filter_record = record.select do |key, value|
+          key.match(@key_pattern_regexp) &&
+            record[key].to_f <= @condition.to_f
+        end
+      when 'string_match'
+        filter_record = record.select do |key, value|
+          key.match(@key_pattern_regexp) &&
+            record[key].match(Regexp.new(@condition))
+        end
+      else
+        raise ArgumentError.new("[out_conditional_filter] no such filter: #{filter}")
+      end
+
+      filter_record
+    end
+  end
+end

--- a/lib/fluent/plugin/conditional_filter_rule.rb
+++ b/lib/fluent/plugin/conditional_filter_rule.rb
@@ -21,7 +21,7 @@ module Fluent
             record[key].match(Regexp.new(@condition))
         end
       else
-        raise ArgumentError.new("[out_conditional_filter] no such filter: #{filter}")
+        raise ArgumentError.new("[conditional_filter_rule] no such filter: #{filter}")
       end
 
       filter_record

--- a/lib/fluent/plugin/filter_conditional.rb
+++ b/lib/fluent/plugin/filter_conditional.rb
@@ -1,6 +1,7 @@
 require 'fluent/plugin/conditional_filter_rule'
+require 'fluent/plugin/filter'
 
-class Fluent::ConditionalFilter < Fluent::Filter
+class Fluent::Plugin::ConditionalFilter < Fluent::Plugin::Filter
   Fluent::Plugin.register_filter('conditional', self)
 
   include Fluent::ConditionalFilterRule

--- a/lib/fluent/plugin/filter_conditional.rb
+++ b/lib/fluent/plugin/filter_conditional.rb
@@ -1,0 +1,23 @@
+require 'fluent/plugin/conditional_filter_rule'
+
+class Fluent::ConditionalFilter < Fluent::Filter
+  Fluent::Plugin.register_filter('conditional', self)
+
+  include Fluent::ConditionalFilterRule
+
+  config_param :key_pattern, :string
+  config_param :condition,   :string
+  config_param :filter,      :string
+
+  def configure(conf)
+    super
+
+    @key_pattern_regexp = Regexp.new(key_pattern)
+  end
+
+  def filter(tag, time, record)
+    record = filter_record(tag, time, record, self)
+
+    record if record.any?
+  end
+end

--- a/spec/lib/filter_conditional_spec.rb
+++ b/spec/lib/filter_conditional_spec.rb
@@ -1,0 +1,220 @@
+require 'spec_helper'
+
+describe Fluent::ConditionalFilter do
+  describe '#configure' do
+
+    context "success" do
+      let(:conf) {
+        %[
+          key_pattern @example\.com$
+          condition   10
+          filter      numeric_upward
+        ]
+      }
+
+      let(:driver) { Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf) }
+      subject {
+        driver
+      }
+
+      it {
+        expect(subject.instance).to be_an_instance_of described_class
+        expect(subject.instance.key_pattern).to be == "@example\.com$"
+        expect(subject.instance.instance_variable_get(:@key_pattern_regexp)).to be == /@example.com$/
+      }
+    end
+
+    context "failure" do
+      context 'key_pattern not set' do
+        let(:conf) {
+          %[
+            condition   10
+            filter      numeric_upward
+          ]
+        }
+
+        it {
+          expect {
+            Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf)
+          }.to raise_error(Fluent::ConfigError)
+        }
+      end
+
+      context 'condition not set' do
+        let(:conf) {
+          %[
+            key_pattern @example.com$
+            filter      numeric_upward
+          ]
+        }
+
+        it {
+          expect {
+            Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf)
+          }.to raise_error(Fluent::ConfigError)
+        }
+      end
+
+      context 'filter not set' do
+        let(:conf) {
+          %[
+            key_pattern @example.com$
+            condition   10
+          ]
+        }
+
+        it {
+          expect {
+            Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf)
+          }.to raise_error(Fluent::ConfigError)
+        }
+      end
+    end
+  end
+
+  describe "#filter" do
+    context('numeric_upward') do
+      let(:conf) {
+        %[
+          key_pattern @example.com$
+          condition   10
+          filter      numeric_upward
+        ]
+      }
+
+      let(:driver) { Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf) }
+
+      context('with 0 matched key/value pair') do
+        before {
+          driver.run {
+            driver.filter('foo@example.com' => 8, 'bar@example.com' => 6, 'baz@baz.com' => 15)
+          }
+        }
+
+        it {
+          expect(driver.filtered_as_array[0]).to be_nil
+        }
+      end
+
+      context('with 1 matched key/value pair') do
+        before {
+          driver.run {
+            driver.filter('foo@example.com' => 12, 'bar@example.com' => 6, 'baz@baz.com' => 15)
+          }
+        }
+
+        it {
+          expect(driver.filtered_as_array[0][2].keys.length).to be == 1
+        }
+      end
+
+      context('with 2 matched key/value pairs') do
+        before {
+          driver.run {
+            driver.filter('foo@example.com' => 12, 'bar@example.com' => 10, 'baz@baz.com' => 15)
+          }
+        }
+
+        it {
+          expect(driver.filtered_as_array[0][2].keys.length).to be == 2
+        }
+      end
+    end
+
+    context('numeric_downward') do
+      let(:conf) {
+        %[
+          key_pattern @example.com$
+          condition   10
+          filter      numeric_downward
+        ]
+      }
+
+      let(:driver) { Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf) }
+
+      context('with 0 matched key/value pair') do
+        before {
+          driver.run {
+            driver.filter('foo@example.com' => 18, 'bar@example.com' => 26, 'baz@baz.com' => 15)
+          }
+        }
+
+        it {
+          expect(driver.filtered_as_array[0]).to be_nil
+        }
+      end
+
+      context('with 1 matched key/value pair') do
+        before {
+          driver.run {
+            driver.filter('foo@example.com' => 11, 'bar@example.com' => 6, 'baz@baz.com' => 5)
+          }
+        }
+
+        it {
+          expect(driver.filtered_as_array[0][2].keys.length).to be == 1
+        }
+      end
+
+      context('with 2 matched key/value pairs') do
+        before {
+          driver.run {
+            driver.filter('foo@example.com' => 10, 'bar@example.com' => 5, 'baz@baz.com' => 5)
+          }
+        }
+
+        it {
+          expect(driver.filtered_as_array[0][2].keys.length).to be == 2
+        }
+      end
+    end
+
+    context('string_match') do
+      let(:conf) {
+        %[
+          key_pattern @example.com$
+          condition   (staff|user)
+          filter      string_match
+        ]
+      }
+
+      let(:driver) { Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf) }
+
+      context('with 0 matched key/value pair') do
+        before {
+          driver.run {
+            driver.filter('foo@example.com' => 'guest', 'bar@example.com' => 'guest', 'baz@baz.com' => 'staff')
+          }
+        }
+
+        it {
+          expect(driver.filtered_as_array[0]).to be_nil
+        }
+      end
+
+      context('with 1 matched key/value pair') do
+        before {
+          driver.run {
+            driver.filter('foo@example.com' => 'staff', 'bar@example.com' => 'guest', 'baz@baz.com' => 'user')
+          }
+        }
+
+        it {
+          expect(driver.filtered_as_array[0][2].keys.length).to be == 1
+        }
+      end
+
+      context('with 2 matched key/value pairs') do
+        before {
+          driver.run {
+            driver.filter('foo@example.com' => 'staff', 'bar@example.com' => 'user', 'baz@baz.com' => 'staff')
+          }
+        }
+
+        it {
+          expect(driver.filtered_as_array[0][2].keys.length).to be == 2
+        }
+      end
+    end
+  end
+end

--- a/spec/lib/filter_conditional_spec.rb
+++ b/spec/lib/filter_conditional_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Fluent::ConditionalFilter do
+describe Fluent::Plugin::ConditionalFilter do
   describe '#configure' do
 
     context "success" do
@@ -12,7 +12,7 @@ describe Fluent::ConditionalFilter do
         ]
       }
 
-      let(:driver) { Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf) }
+      let(:driver) { Fluent::Test::Driver::Filter.new(described_class).configure(conf) }
       subject {
         driver
       }
@@ -35,7 +35,7 @@ describe Fluent::ConditionalFilter do
 
         it {
           expect {
-            Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf)
+            Fluent::Test::Driver::Filter.new(described_class).configure(conf)
           }.to raise_error(Fluent::ConfigError)
         }
       end
@@ -50,7 +50,7 @@ describe Fluent::ConditionalFilter do
 
         it {
           expect {
-            Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf)
+            Fluent::Test::Driver::Filter.new(described_class).configure(conf)
           }.to raise_error(Fluent::ConfigError)
         }
       end
@@ -65,7 +65,7 @@ describe Fluent::ConditionalFilter do
 
         it {
           expect {
-            Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf)
+            Fluent::Test::Driver::Filter.new(described_class).configure(conf)
           }.to raise_error(Fluent::ConfigError)
         }
       end
@@ -82,41 +82,41 @@ describe Fluent::ConditionalFilter do
         ]
       }
 
-      let(:driver) { Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf) }
+      let(:driver) { Fluent::Test::Driver::Filter.new(described_class).configure(conf) }
 
       context('with 0 matched key/value pair') do
         before {
-          driver.run {
-            driver.filter('foo@example.com' => 8, 'bar@example.com' => 6, 'baz@baz.com' => 15)
+          driver.run(default_tag: 'test') {
+            driver.feed('foo@example.com' => 8, 'bar@example.com' => 6, 'baz@baz.com' => 15)
           }
         }
 
         it {
-          expect(driver.filtered_as_array[0]).to be_nil
+          expect(driver.filtered[0]).to be_nil
         }
       end
 
       context('with 1 matched key/value pair') do
         before {
-          driver.run {
-            driver.filter('foo@example.com' => 12, 'bar@example.com' => 6, 'baz@baz.com' => 15)
+          driver.run(default_tag: 'test') {
+            driver.feed('foo@example.com' => 12, 'bar@example.com' => 6, 'baz@baz.com' => 15)
           }
         }
 
         it {
-          expect(driver.filtered_as_array[0][2].keys.length).to be == 1
+          expect(driver.filtered[0][1].keys.length).to be == 1
         }
       end
 
       context('with 2 matched key/value pairs') do
         before {
-          driver.run {
-            driver.filter('foo@example.com' => 12, 'bar@example.com' => 10, 'baz@baz.com' => 15)
+          driver.run(default_tag: 'test') {
+            driver.feed('foo@example.com' => 12, 'bar@example.com' => 10, 'baz@baz.com' => 15)
           }
         }
 
         it {
-          expect(driver.filtered_as_array[0][2].keys.length).to be == 2
+          expect(driver.filtered[0][1].keys.length).to be == 2
         }
       end
     end
@@ -130,41 +130,41 @@ describe Fluent::ConditionalFilter do
         ]
       }
 
-      let(:driver) { Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf) }
+      let(:driver) { Fluent::Test::Driver::Filter.new(described_class).configure(conf) }
 
       context('with 0 matched key/value pair') do
         before {
-          driver.run {
-            driver.filter('foo@example.com' => 18, 'bar@example.com' => 26, 'baz@baz.com' => 15)
+          driver.run(default_tag: 'test') {
+            driver.feed('foo@example.com' => 18, 'bar@example.com' => 26, 'baz@baz.com' => 15)
           }
         }
 
         it {
-          expect(driver.filtered_as_array[0]).to be_nil
+          expect(driver.filtered[0]).to be_nil
         }
       end
 
       context('with 1 matched key/value pair') do
         before {
-          driver.run {
-            driver.filter('foo@example.com' => 11, 'bar@example.com' => 6, 'baz@baz.com' => 5)
+          driver.run(default_tag: 'test') {
+            driver.feed('foo@example.com' => 11, 'bar@example.com' => 6, 'baz@baz.com' => 5)
           }
         }
 
         it {
-          expect(driver.filtered_as_array[0][2].keys.length).to be == 1
+          expect(driver.filtered[0][1].keys.length).to be == 1
         }
       end
 
       context('with 2 matched key/value pairs') do
         before {
-          driver.run {
-            driver.filter('foo@example.com' => 10, 'bar@example.com' => 5, 'baz@baz.com' => 5)
+          driver.run(default_tag: 'test') {
+            driver.feed('foo@example.com' => 10, 'bar@example.com' => 5, 'baz@baz.com' => 5)
           }
         }
 
         it {
-          expect(driver.filtered_as_array[0][2].keys.length).to be == 2
+          expect(driver.filtered[0][1].keys.length).to be == 2
         }
       end
     end
@@ -178,41 +178,41 @@ describe Fluent::ConditionalFilter do
         ]
       }
 
-      let(:driver) { Fluent::Test::FilterTestDriver.new(described_class, 'test').configure(conf) }
+      let(:driver) { Fluent::Test::Driver::Filter.new(described_class).configure(conf) }
 
       context('with 0 matched key/value pair') do
         before {
-          driver.run {
-            driver.filter('foo@example.com' => 'guest', 'bar@example.com' => 'guest', 'baz@baz.com' => 'staff')
+          driver.run(default_tag: 'test') {
+            driver.feed('foo@example.com' => 'guest', 'bar@example.com' => 'guest', 'baz@baz.com' => 'staff')
           }
         }
 
         it {
-          expect(driver.filtered_as_array[0]).to be_nil
+          expect(driver.filtered[0]).to be_nil
         }
       end
 
       context('with 1 matched key/value pair') do
         before {
-          driver.run {
-            driver.filter('foo@example.com' => 'staff', 'bar@example.com' => 'guest', 'baz@baz.com' => 'user')
+          driver.run(default_tag: 'test') {
+            driver.feed('foo@example.com' => 'staff', 'bar@example.com' => 'guest', 'baz@baz.com' => 'user')
           }
         }
 
         it {
-          expect(driver.filtered_as_array[0][2].keys.length).to be == 1
+          expect(driver.filtered[0][1].keys.length).to be == 1
         }
       end
 
       context('with 2 matched key/value pairs') do
         before {
-          driver.run {
-            driver.filter('foo@example.com' => 'staff', 'bar@example.com' => 'user', 'baz@baz.com' => 'staff')
+          driver.run(default_tag: 'test') {
+            driver.feed('foo@example.com' => 'staff', 'bar@example.com' => 'user', 'baz@baz.com' => 'staff')
           }
         }
 
         it {
-          expect(driver.filtered_as_array[0][2].keys.length).to be == 2
+          expect(driver.filtered[0][1].keys.length).to be == 2
         }
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'fluent/test'
+require 'fluent/test/driver/filter'
 require 'fluent/plugin/out_conditional_filter'
 require 'fluent/plugin/filter_conditional'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'fluent/test'
 require 'fluent/plugin/out_conditional_filter'
+require 'fluent/plugin/filter_conditional'
 
 RSpec.configure do |config|
   config.before(:all) do
@@ -24,4 +25,3 @@ unless ENV.has_key?('VERBOSE')
   }
   $log = nulllogger
 end
-


### PR DESCRIPTION
Please review this PR after #6 is merged.

---
I've tried to migrate to use v0.14 Filter Plugin API.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.